### PR TITLE
Add details to the task struct

### DIFF
--- a/amclient.go
+++ b/amclient.go
@@ -212,6 +212,20 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 	return response, err
 }
 
+func addOption(rawURL, key, value string) (string, error) {
+	origURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+
+	queryValues := origURL.Query()
+	queryValues.Set(key, value)
+
+	origURL.RawQuery = queryValues.Encode()
+
+	return origURL.String(), nil
+}
+
 // CheckResponse checks the API response for errors, and returns them if
 // present. A response is considered an error if it has a status code outside
 // the 200 range. API error responses are expected to have either no response

--- a/amclient_test.go
+++ b/amclient_test.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+
+	"gotest.tools/v3/assert"
 )
 
 var (
@@ -147,4 +149,31 @@ func TestNewRequestJSON(t *testing.T) {
 	if !bytes.Equal(got, want) {
 		t.Fatalf("NewRequest() Body, got: %s, want %s", got, want)
 	}
+}
+
+func TestAddOption(t *testing.T) {
+	var (
+		rawURL = "http://127.0.0.1:12345"
+		err    error
+	)
+
+	// It can set a query parameter.
+	rawURL, err = addOption(rawURL, "param1", "1")
+	assert.NilError(t, err)
+	assert.Equal(t, rawURL, "http://127.0.0.1:12345?param1=1")
+
+	// It can overwrite a query parameter.
+	rawURL, err = addOption(rawURL, "param1", "2")
+	assert.NilError(t, err)
+	assert.Equal(t, rawURL, "http://127.0.0.1:12345?param1=2")
+
+	// It can append an additional query parameter.
+	rawURL, err = addOption(rawURL, "param2", "a")
+	assert.NilError(t, err)
+	assert.Equal(t, rawURL, "http://127.0.0.1:12345?param1=2&param2=a")
+
+	// It can set an empty string as a query parameter.
+	rawURL, err = addOption(rawURL, "param3", "")
+	assert.NilError(t, err)
+	assert.Equal(t, rawURL, "http://127.0.0.1:12345?param1=2&param2=a&param3=")
 }

--- a/amclienttest/mock_v2_task.go
+++ b/amclienttest/mock_v2_task.go
@@ -36,10 +36,10 @@ func (m *MockTaskService) EXPECT() *MockTaskServiceMockRecorder {
 }
 
 // Read mocks base method.
-func (m *MockTaskService) Read(arg0 context.Context, arg1 string) (*amclient.TaskDetailed, *amclient.Response, error) {
+func (m *MockTaskService) Read(arg0 context.Context, arg1 string) (*amclient.Task, *amclient.Response, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Read", arg0, arg1)
-	ret0, _ := ret[0].(*amclient.TaskDetailed)
+	ret0, _ := ret[0].(*amclient.Task)
 	ret1, _ := ret[1].(*amclient.Response)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -58,19 +58,19 @@ type TaskServiceReadCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *TaskServiceReadCall) Return(arg0 *amclient.TaskDetailed, arg1 *amclient.Response, arg2 error) *TaskServiceReadCall {
+func (c *TaskServiceReadCall) Return(arg0 *amclient.Task, arg1 *amclient.Response, arg2 error) *TaskServiceReadCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *TaskServiceReadCall) Do(f func(context.Context, string) (*amclient.TaskDetailed, *amclient.Response, error)) *TaskServiceReadCall {
+func (c *TaskServiceReadCall) Do(f func(context.Context, string) (*amclient.Task, *amclient.Response, error)) *TaskServiceReadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *TaskServiceReadCall) DoAndReturn(f func(context.Context, string) (*amclient.TaskDetailed, *amclient.Response, error)) *TaskServiceReadCall {
+func (c *TaskServiceReadCall) DoAndReturn(f func(context.Context, string) (*amclient.Task, *amclient.Response, error)) *TaskServiceReadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/v2_jobs_test.go
+++ b/v2_jobs_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 )
@@ -14,6 +15,8 @@ func TestJobs_List(t *testing.T) {
 
 	mux.HandleFunc("/api/v2beta/jobs/e99afef7-90c5-4fd9-bf8f-bed13b3bd4ba/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		assert.Assert(t, r.URL.Query().Has("detailed") && r.URL.Query().Get("detailed") == "")
+
 		fmt.Fprint(w, `[
 	{
 		"uuid": "624581dc-ec01-4195-9da3-db0ab0ad1cc3",
@@ -24,7 +27,12 @@ func TestJobs_List(t *testing.T) {
 		"tasks": [
 			{
 				"uuid": "491aebbd-457b-4a6e-adf6-87a3a9ee951a",
-				"exit_code": 1
+				"exit_code": 1,
+				"file_name": "Images-94ade01c-49ce-49e0-9cc3-805575c676d0",
+				"time_created": "2024-01-18T01:27:49",
+				"time_started": "2024-01-18T01:27:49",
+				"time_ended": "2024-01-18T01:27:49",
+				"duration": "< 1"
 			}
 		]
 	}
@@ -32,7 +40,8 @@ func TestJobs_List(t *testing.T) {
 	})
 
 	payload, _, err := client.Jobs.List(ctx, "e99afef7-90c5-4fd9-bf8f-bed13b3bd4ba", &JobsListRequest{
-		LinkID: "6ce08b95-1b3b-498a-8baa-e595e2ae7466",
+		LinkID:   "6ce08b95-1b3b-498a-8baa-e595e2ae7466",
+		Detailed: true,
 	})
 
 	assert.NilError(t, err)
@@ -45,8 +54,13 @@ func TestJobs_List(t *testing.T) {
 			LinkID:       "6ce08b95-1b3b-498a-8baa-e595e2ae7466",
 			Tasks: []Task{
 				{
-					ID:       "491aebbd-457b-4a6e-adf6-87a3a9ee951a",
-					ExitCode: 1,
+					ID:          "491aebbd-457b-4a6e-adf6-87a3a9ee951a",
+					ExitCode:    1,
+					Filename:    "Images-94ade01c-49ce-49e0-9cc3-805575c676d0",
+					CreatedAt:   TaskDateTime{time.Date(2024, time.January, 18, 1, 27, 49, 0, time.UTC)},
+					StartedAt:   TaskDateTime{time.Date(2024, time.January, 18, 1, 27, 49, 0, time.UTC)},
+					CompletedAt: TaskDateTime{time.Date(2024, time.January, 18, 1, 27, 49, 0, time.UTC)},
+					Duration:    TaskDuration(time.Second / 2),
 				},
 			},
 		},

--- a/v2_task.go
+++ b/v2_task.go
@@ -1,15 +1,17 @@
 package amclient
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 )
 
 const taskBasePath = "api/v2beta/task"
 
 type TaskService interface {
-	Read(context.Context, string) (*TaskDetailed, *Response, error)
+	Read(context.Context, string) (*Task, *Response, error)
 }
 
 type TaskServiceOp struct {
@@ -25,7 +27,8 @@ type TaskDateTime struct {
 func (t *TaskDateTime) UnmarshalJSON(data []byte) error {
 	s := string(data)
 	s = s[1 : len(s)-1]
-	td, err := time.Parse("2006-01-02T15:04:05", s)
+	const layout = "2006-01-02T15:04:05"
+	td, err := time.Parse(layout, s)
 	if err != nil {
 		return err
 	}
@@ -33,18 +36,57 @@ func (t *TaskDateTime) UnmarshalJSON(data []byte) error {
 	return err
 }
 
-type TaskDetailed struct {
-	ID          string       `json:"uuid"`
-	ExitCode    uint8        `json:"exit_code"`
-	FileID      string       `json:"file_uuid"`
-	Filename    string       `json:"file_name"`
-	TimeCreated TaskDateTime `json:"time_created"`
-	TimeStarted TaskDateTime `json:"time_started"`
-	TimeEnded   TaskDateTime `json:"time_ended"`
-	Duration    uint32       `json:"duration"`
+// TaskDuration extends the standard time.Duration type to provide specialized
+// unmarshaling from JSON. Unlike time.Duration, which typically requires
+// duration values to be specified in string format (like "300ms", "1h30m"),
+// TaskDuration is designed to unmarshal from two distinct JSON value types:
+//
+//  1. Integer values representing the duration in seconds.
+//  2. A specific string literal "< 1", which we interpret as half a second.
+//
+// Examples:
+//   - `{"duration": 60}` unmarshals to 60 seconds,
+//   - `{"duration": "< 1"}` unmarshals to 500 milliseconds.
+//
+// Python function: https://github.com/artefactual/archivematica/blob/2c03a79e710d655c3740ddbc4bc62eebd4e4b4fe/src/dashboard/src/components/helpers.py#L163-L170.
+type TaskDuration time.Duration
+
+func (d *TaskDuration) UnmarshalJSON(data []byte) error {
+	// Check for the special "< 1" case.
+	if bytes.Equal(data, []byte("\"< 1\"")) {
+		*d = TaskDuration(time.Second / 2)
+		return nil
+	}
+
+	// Check for the empty string case.
+	if bytes.Equal(data, []byte("\"\"")) {
+		*d = TaskDuration(0)
+		return nil
+	}
+
+	// Parse the integer value.
+	seconds, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	*d = TaskDuration(time.Duration(seconds) * time.Second)
+
+	return nil
 }
 
-func (s *TaskServiceOp) Read(ctx context.Context, ID string) (*TaskDetailed, *Response, error) {
+type Task struct {
+	ID          string       `json:"uuid"`
+	ExitCode    int          `json:"exit_code"`
+	FileID      string       `json:"file_uuid"`
+	Filename    string       `json:"file_name"`
+	CreatedAt   TaskDateTime `json:"time_created"`
+	StartedAt   TaskDateTime `json:"time_started"`
+	CompletedAt TaskDateTime `json:"time_ended"`
+	Duration    TaskDuration `json:"duration"`
+}
+
+func (s *TaskServiceOp) Read(ctx context.Context, ID string) (*Task, *Response, error) {
 	path := fmt.Sprintf("%s/%s", taskBasePath, ID)
 
 	req, err := s.client.NewRequestJSON(ctx, "GET", path, nil)
@@ -52,7 +94,7 @@ func (s *TaskServiceOp) Read(ctx context.Context, ID string) (*TaskDetailed, *Re
 		return nil, nil, err
 	}
 
-	payload := &TaskDetailed{}
+	payload := &Task{}
 	resp, err := s.client.Do(ctx, req, payload)
 
 	return payload, resp, err

--- a/v2_task_test.go
+++ b/v2_task_test.go
@@ -1,6 +1,7 @@
 package amclient
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -30,14 +31,102 @@ func TestTask_Read(t *testing.T) {
 	payload, _, err := client.Task.Read(ctx, "96acb0a1-525c-456a-9060-51bb84f5f708")
 
 	assert.NilError(t, err)
-	assert.DeepEqual(t, &TaskDetailed{
+	assert.DeepEqual(t, &Task{
 		ID:          "96acb0a1-525c-456a-9060-51bb84f5f708",
 		ExitCode:    1,
 		FileID:      "e502c0d9-becf-455a-8b20-091526947a09",
-		TimeCreated: TaskDateTime{Time: time.Date(2019, time.June, 18, 0, 0, 0, 0, time.UTC)},
-		TimeStarted: TaskDateTime{Time: time.Date(2019, time.July, 18, 0, 0, 0, 0, time.UTC)},
-		TimeEnded:   TaskDateTime{Time: time.Date(2019, time.August, 18, 0, 0, 0, 0, time.UTC)},
+		CreatedAt:   TaskDateTime{Time: time.Date(2019, time.June, 18, 0, 0, 0, 0, time.UTC)},
+		StartedAt:   TaskDateTime{Time: time.Date(2019, time.July, 18, 0, 0, 0, 0, time.UTC)},
+		CompletedAt: TaskDateTime{Time: time.Date(2019, time.August, 18, 0, 0, 0, 0, time.UTC)},
 		Filename:    "foobar.txt",
-		Duration:    4294967295,
+		Duration:    TaskDuration(4294967295 * time.Second),
 	}, payload)
+}
+
+func TestTaskDateTimeUnmarshalJSON(t *testing.T) {
+	tests := map[string]struct {
+		input     string
+		expected  TaskDateTime
+		expectErr bool
+	}{
+		"Expected format": {
+			input:    `"2006-01-02T15:04:05"`,
+			expected: TaskDateTime{Time: time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC)},
+		},
+		"Unexpected format": {
+			input:     `"2006-01-02T15:04:05Z"`,
+			expectErr: true,
+		},
+		"Empty string": {
+			input:     `"2006-01-02T15:04:05Z"`,
+			expectErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var dt TaskDateTime
+
+			err := json.Unmarshal([]byte(tt.input), &dt)
+
+			if tt.expectErr {
+				assert.Assert(t, err != nil)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, dt, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTaskDurationUnmarshalJSON(t *testing.T) {
+	tests := map[string]struct {
+		input     string
+		expected  TaskDuration
+		expectErr bool
+	}{
+		"Integer literal": {
+			input:    `30`,
+			expected: TaskDuration(30 * time.Second),
+		},
+		"Negative integer": {
+			input:    `-10`,
+			expected: TaskDuration(-10 * time.Second),
+		},
+		"Minus one": {
+			input:    `"< 1"`,
+			expected: TaskDuration(time.Second / 2),
+		},
+		"Empty string": {
+			input:    `""`,
+			expected: TaskDuration(0),
+		},
+		"Invalid string": {
+			input:     `"invalid"`,
+			expectErr: true,
+		},
+		"Invalid string with < symbol": {
+			input:     `"inv < alid"`,
+			expectErr: true,
+		},
+		"Invalid integer (too big)": {
+			input:     `123456789012345678901234567890123456789`,
+			expectErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var dur TaskDuration
+
+			err := json.Unmarshal([]byte(tt.input), &dur)
+
+			if tt.expectErr {
+				assert.Assert(t, err != nil)
+			} else {
+				assert.NilError(t, err)
+				assert.Equal(t, dur, tt.expected)
+			}
+		})
+	}
 }


### PR DESCRIPTION
- `JobsListRequest` struct now comes with a detailed field to get more verbose output from the archivematica API.
- Breaking changes with the current API.
- Removes `TaskDetailed` and moves the fields in `TaskDetailed` to the `Task` Struct.
- Test for `Job` changed for detailed output.
- Types for `Task` struct changed.
- New custom unmarshall function for encapsulated type `Duration` added.

Refs artefactual-sdps/enduro#832
