### PR TITLE
Update JSON decoding for TaskDateTime and TaskDuration

### DIFF
--- a/v2_task_test.go
+++ b/v2_task_test.go
@@ -53,12 +53,16 @@ func TestTaskDateTimeUnmarshalJSON(t *testing.T) {
 			input:    `"2006-01-02T15:04:05"`,
 			expected: TaskDateTime{Time: time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC)},
 		},
+		"Null": {
+			input:    `null`,
+			expected: TaskDateTime{},
+		},
 		"Unexpected format": {
 			input:     `"2006-01-02T15:04:05Z"`,
 			expectErr: true,
 		},
 		"Empty string": {
-			input:     `"2006-01-02T15:04:05Z"`,
+			input:     `""`,
 			expectErr: true,
 		},
 	}
@@ -111,6 +115,10 @@ func TestTaskDurationUnmarshalJSON(t *testing.T) {
 		},
 		"Invalid integer (too big)": {
 			input:     `123456789012345678901234567890123456789`,
+			expectErr: true,
+		},
+		"Null": {
+			input:     `null`,
 			expectErr: true,
 		},
 	}


### PR DESCRIPTION
This PR modifies the JSON unmarshaling behavior of two task fields:

- `TaskDateTime` must expect `null` and return `time.Time{}` (the zero value).
- `TaskDuration` must reject `null` with an error.

These changes align with [Archivematica's implementation](https://github.com/artefactual/archivematica/blob/c757adeec61bfdb7dfd530a7db9821af4b2af55e/src/dashboard/src/components/api/views.py#L885-L899): 

- `format_datetime` may return `None` (encoded as `null` in JSON)
- `task_duration_in_seconds` returns either a string or an integer

I've also updated the [specification](https://artefactual-labs.github.io/archivematica-api-specification/#operation/Tasks_read): `time_started` and `time_ended` are not required fields.

Fixes https://github.com/artefactual-labs/amclient-go/issues/3.